### PR TITLE
ci: add new CD workflow file

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy Chan-Ko Website to GCP
+
+on:
+  push:
+    tags:
+      - 'v*' # This will trigger the workflow for any tag starting with 'v'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '22'
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v3
+      name: Setup pnpm cache
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install --filter chan-ko-website
+
+    - name: Build website
+      run: pnpm --filter chan-ko-website build
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: ${{ secrets.CHANKO_WEBSITE_GCP_PROJECT_ID }}
+        service_account_key: ${{ secrets.CHANKO_WEBSITE_GCP_SA_KEY }}
+        export_default_credentials: true
+
+    - name: Deploy to GCP
+      run: |
+        if ! gcloud compute instances describe ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }}; then
+          gcloud compute instances create ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} \
+            --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} \
+            --machine-type=e2-micro \
+            --tags=http-server,https-server \
+            --metadata=startup-script='#! /bin/bash
+              apt-get update
+              apt-get install -y nginx
+              systemctl start nginx
+            '
+        fi
+        gcloud compute scp --recurse --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} packages/chan-ko-website/dist/* ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }}:/var/www/html/
+        gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='sudo systemctl restart nginx'
+
+
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v2
       with:
-        version: 8
+        version: 9
 
     - name: Get pnpm store directory
       id: pnpm-cache


### PR DESCRIPTION
# Key changes in this new workflow:

Trigger: The `on` section triggers on tag pushes that start with 'v'.
Release Creation: A new step has been added at the end to create a GitHub Release for the tag.

With this setup, here's how we would deploy a new version:

1. Make changes and commit them to `main` branch as usual.
1. When  ready to deploy, create and push a new tag:
    ```bash
    git tag v1.0.0
    git push origin v1.0.0
    ```
    Replace v1.0.0 with whatever version number is appropriate.
1. This will trigger the workflow, which will build our project and deploy it to GCP.
1. After successful deployment, a new GitHub Release will be created for this tag.

## Notes on `secrets.GITHUB_TOKEN`:
The `secrets.GITHUB_TOKEN` is a special token provided automatically by GitHub Actions. You don't need to manually create or manage this token. Let me explain it in more detail:

1. What is secrets.GITHUB_TOKEN? It's a temporary access token that GitHub automatically creates for each workflow run. This token allows the workflow to interact with your GitHub repository.
2. Purpose: The GITHUB_TOKEN is used to authenticate on behalf of GitHub Actions with your repository. In our workflow, it's specifically used to create a GitHub Release.
3. Permissions: By default, the GITHUB_TOKEN has read and write permissions for most scopes required to manage your repository, including:
    * Creating releases
    * Pushing and pulling from the repository
    * Opening and commenting on issues and pull requests
    * Running workflows
4. How to use it: You can use secrets.GITHUB_TOKEN in your workflow file exactly as we've done in the "Create GitHub Release" step. GitHub Actions automatically replaces this with the actual token at runtime.
5. Security:
    * The token is only valid for the duration of the workflow run.
    * It's automatically revoked when the job finishes.
    * Each new workflow run gets a new token.
6. Customizing permissions: If needed, you can customize the permissions of the GITHUB_TOKEN. This is done in the workflow file, like this:
    ```yaml
    permissions:
      contents: write
      issues: read
      pull-requests: write
    ```
7. No setup required: You don't need to create this token or add it to your repository secrets. GitHub handles all of this automatically.

In our workflow, we're using `secrets.GITHUB_TOKEN` specifically for creating a GitHub Release. This action requires permission to create releases in your repository, which the default `GITHUB_TOKEN` has.
If you ever need to perform actions that require more privileges than the `GITHUB_TOKEN` provides (like pushing to a different repository), you would need to create a Personal Access Token (PAT) and add it to your repository secrets manually.
It's worth noting that while `secrets.GITHUB_TOKEN` is very convenient and secure for most use cases, it does have some limitations. For example, it can't be used to trigger new workflow runs (to prevent accidental recursive workflow triggers). If you ever need to bypass these limitations, you would need to use a PAT instead.