### PR TITLE
fix: updates workflow to properly authenticate

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -42,12 +42,15 @@ jobs:
     - name: Build website
       run: pnpm --filter chan-ko-website build
 
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.CHANKO_WEBSITE_GCP_SA_KEY }}
+
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
       with:
         project_id: ${{ secrets.CHANKO_WEBSITE_GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.CHANKO_WEBSITE_GCP_SA_KEY }}
-        export_default_credentials: true
 
     - name: Deploy to GCP
       run: |


### PR DESCRIPTION
It seems the Google Cloud authentication step in our previous workflow was outdated. We've update the workflow to use the current recommended method for authenticating with Google Cloud in GitHub Actions. 

Key changes in this updated workflow:

1. Google Cloud Authentication:
   We've added a new step `Authenticate to Google Cloud` using the `google-github-actions/auth@v1` action. This is the recommended way to authenticate with Google Cloud in GitHub Actions.

2. Cloud SDK Setup:
   We've simplified the `Set up Cloud SDK` step. It now only needs the project ID, as the authentication is handled by the previous step.

3. Removed Unnecessary Parameters:
   We've removed the `service_account_key` and `export_default_credentials` parameters from the `setup-gcloud` action, as they're no longer needed with the new authentication method.

Additional considerations:

1. GCP Service Account Key:
   Ensure that your `GCP_SA_KEY` secret in GitHub contains the entire JSON key file content for your Google Cloud service account.

2. Service Account Permissions:
   Make sure the service account associated with the key has the necessary permissions to create and manage Compute Engine instances, as well as to use Cloud Storage (for the `gcloud compute scp` command).

3. Project Configuration:
   Double-check that your `GCP_PROJECT_ID`, `GCP_INSTANCE_NAME`, and `GCP_ZONE` secrets are correctly set in your GitHub repository settings.

4. Error Handling:
   The current script will fail if it can't create the instance. Depending on your needs, you might want to add more robust error handling or logging.

5. Security:
   Remember that the startup script is running as root. Be cautious about what you include in it, and consider moving complex setup to a separate script that you can version control and test independently.

6. Optimization:
   Depending on your deployment frequency, you might want to consider using a custom image with nginx pre-installed, rather than installing it every time in the startup script.

With these changes, your workflow should now correctly authenticate with Google Cloud and be able to create and manage your Compute Engine instance. If you encounter any more issues, please provide the new error messages, and I'll be happy to help you troubleshoot further.