### PR TITLE
fix: adds checks to workflow for nginx

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -62,13 +62,34 @@ jobs:
             --metadata=startup-script='#! /bin/bash
               apt-get update
               apt-get install -y nginx
-              mkdir -p /var/www/html
-              chown -R www-data:www-data /var/www/html
+              systemctl enable nginx
               systemctl start nginx
             '
         fi
 
-        sleep 60
+        echo "Waiting for instance to be ready..."
+        sleep 90
+
+        echo "Ensure nginx is installed and running"
+        gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='
+          if ! command -v nginx &> /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y nginx
+          fi
+          sudo systemctl enable nginx
+          sudo systemctl start nginx
+          sudo mkdir -p /var/www/html
+          sudo chown -R $(whoami):$(whoami) /var/www/html
+        '
+
+        echo "Copying files..."
+        gcloud compute scp --recurse --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} packages/chan-ko-website/dist/* ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }}:/var/www/html/
+
+        echo "Setting permissions and restarting nginx..."
+        gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='
+          sudo chown -R www-data:www-data /var/www/html
+          sudo systemctl restart nginx
+        '
 
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='sudo mkdir -p /var/www/html && sudo chown -R $(whoami):$(whoami) /var/www/html'
         gcloud compute scp --recurse --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} packages/chan-ko-website/dist/* ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }}:/var/www/html/


### PR DESCRIPTION
We were receiving the following error previously:
```shell
+----[SHA256]-----+
Updating project ssh metadata...
...............................................Updated [https://www.googleapis.com/compute/v1/projects/***].
.done.
Waiting for SSH key to propagate.
Warning: Permanently added 'compute.5013814596737629666' (ED25519) to the list of known hosts.
Failed to restart nginx.service: Unit nginx.service not found.
Error: Process completed with exit code 5.
```

The error is saying that nginx is not installed on our Debian-based GCE instance. Let's modify the workflow to account for this and ensure nginx is properly installed and configured. Here's an updated version of the deployment step:


```yaml
name: Deploy to GCP

on:
  push:
    tags:
      - 'v*' # This will trigger the workflow for any tag starting with 'v'

jobs:
  deploy:
    runs-on: ubuntu-latest

    steps:
    # ... previous steps remain the same ...

    - name: Deploy to GCP
      run: |
        if ! gcloud compute instances describe ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }}; then
          gcloud compute instances create ${{ secrets.GCP_INSTANCE_NAME }} \
            --zone=${{ secrets.GCP_ZONE }} \
            --machine-type=e2-micro \
            --tags=http-server,https-server \
            --metadata=startup-script='#! /bin/bash
              apt-get update
              apt-get install -y nginx
              systemctl enable nginx
              systemctl start nginx
            '
        fi
        
        # Wait for instance to be ready
        echo "Waiting for instance to be ready..."
        sleep 90
        
        # Ensure nginx is installed and running
        gcloud compute ssh ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }} --command='
          if ! command -v nginx &> /dev/null; then
            sudo apt-get update
            sudo apt-get install -y nginx
          fi
          sudo systemctl enable nginx
          sudo systemctl start nginx
          sudo mkdir -p /var/www/html
          sudo chown -R $(whoami):$(whoami) /var/www/html
        '
        
        # Copy files
        echo "Copying files..."
        gcloud compute scp --recurse --zone=${{ secrets.GCP_ZONE }} packages/chan-ko-website/dist/* ${{ secrets.GCP_INSTANCE_NAME }}:/var/www/html/
        
        # Set correct permissions and restart nginx
        echo "Setting permissions and restarting nginx..."
        gcloud compute ssh ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }} --command='
          sudo chown -R www-data:www-data /var/www/html
          sudo systemctl restart nginx
        '

    # ... rest of the workflow remains the same ...

```

Key changes in this updated deployment step:

1. Startup Script:
   We've modified the startup script to install nginx, enable it, and start it. This should work for Debian-based systems.

2. Wait Time:
   Increased the wait time to 90 seconds to allow more time for the instance to be fully ready and for the startup script to complete.

3. Nginx Installation Check:
   Before copying files, we check if nginx is installed. If it's not, we install it, enable it, and start it.

4. Error Handling:
   Added echo statements to provide more visibility into the deployment process.

5. Directory Creation:
   We ensure the `/var/www/html` directory exists and has the correct permissions.

Additional considerations for Debian-based systems:

1. Package Manager:
   Debian uses `apt-get` as its package manager, which we're using in the scripts.

2. Systemd:
   We're using `systemctl` commands, which should work on modern Debian systems that use systemd.

3. Firewall:
   Debian might not have a firewall enabled by default. If you need to configure a firewall, you might want to add commands to set up `ufw` or `iptables`.

4. Nginx Configuration:
   The default Debian nginx configuration should serve files from `/var/www/html`, but you might want to add a custom configuration if you need specific settings.

5. Non-root User:
   If your GCE instance is set up to use a non-root user by default, you might need to adjust the commands to use `sudo` where necessary.

6. Idempotency:
   The current script will attempt to install nginx every time. This is fine as `apt-get install` is idempotent, but you could optimize this if needed.

If we encounter any more issues or need further modifications, it might be helpful to see the output of `gcloud compute ssh ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }} --command='cat /var/log/syslog'` to check for any startup script errors if problems persist.