### PR TITLE
feat: deploy now enables HTTPS support

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -55,6 +55,7 @@ jobs:
     - name: Deploy to GCP
       env:
         DOMAIN: chan-ko.com
+        CERTBOT_EMAIL: ${{ secrets.CHANKO_DEVOPS_EMAIL }}
       run: |
         if ! gcloud compute instances describe ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }}; then
           gcloud compute instances create ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} \
@@ -84,7 +85,7 @@ jobs:
           sudo chown -R $(whoami):$(whoami) /var/www/html
 
           echo "Obtaining SSL certificate"
-          sudo certbot --nginx -d '"$DOMAIN"' --non-interactive --agree-tos --email devops@chan-ko.com
+          sudo certbot --nginx -d '"$DOMAIN"' --non-interactive --agree-tos --email '"$CERTBOT_EMAIL"'
         '
 
         echo "Copying files..."

--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -85,7 +85,13 @@ jobs:
           sudo chown -R $(whoami):$(whoami) /var/www/html
 
           echo "Obtaining SSL certificate"
-          sudo certbot --nginx -d '"$DOMAIN"' --non-interactive --agree-tos --email '"$CERTBOT_EMAIL"'
+          if sudo certbot certificates | grep -q "$DOMAIN"; then
+            echo "Certificate for $DOMAIN already exists. Attempting renewal if necessary."
+            sudo certbot renew --nginx --non-interactive
+          else
+            echo "No certificate found for $DOMAIN. Creating a new one."
+            sudo certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --email "$CERTBOT_EMAIL"
+          fi
         '
 
         echo "Copying files..."
@@ -95,29 +101,29 @@ jobs:
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='
           sudo chown -R www-data:www-data /var/www/html
 
-          echo '"Updating Nginx config to force HTTPS"'
-          sudo bash -c "cat > /etc/nginx/sites-available/default << EOF
+          echo "Updating Nginx config to force HTTPS"
+          sudo bash -c '"'"'cat > /etc/nginx/sites-available/default << EOL
           server {
-              listen 80;
-              server_name '"$DOMAIN"';
-              return 301 https://\$server_name\$request_uri;
+            listen 80;
+            server_name '"$DOMAIN"';
+            return 301 https://\$server_name\$request_uri;
           }
 
           server {
-              listen 443 ssl;
-              server_name '"$DOMAIN"';
+            listen 443 ssl;
+            server_name '"$DOMAIN"';
 
-              ssl_certificate /etc/letsencrypt/live/'"$DOMAIN"'/fullchain.pem;
-              ssl_certificate_key /etc/letsencrypt/live/'"$DOMAIN"'/privkey.pem;
+            ssl_certificate /etc/letsencrypt/live/'"$DOMAIN"'/fullchain.pem;
+            ssl_certificate_key /etc/letsencrypt/live/'"$DOMAIN"'/privkey.pem;
 
-              root /var/www/html;
-              index index.html;
+            root /var/www/html;
+            index index.html;
 
-              location / {
-                  try_files \$uri \$uri/ =404;
-              }
+            location / {
+                try_files \$uri \$uri/ =404;
+            }
           }
-          EOF"
+          EOL'"'"'
 
           sudo nginx -t && sudo systemctl restart nginx
         '
@@ -125,7 +131,6 @@ jobs:
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='sudo mkdir -p /var/www/html && sudo chown -R $(whoami):$(whoami) /var/www/html'
         gcloud compute scp --recurse --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} packages/chan-ko-website/dist/* ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }}:/var/www/html/
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='sudo systemctl restart nginx'
-
 
     - name: Create GitHub Release
       uses: actions/create-release@v1

--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -53,6 +53,8 @@ jobs:
         project_id: ${{ secrets.CHANKO_WEBSITE_GCP_PROJECT_ID }}
 
     - name: Deploy to GCP
+      env:
+        DOMAIN: chan-ko.com
       run: |
         if ! gcloud compute instances describe ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }}; then
           gcloud compute instances create ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} \
@@ -61,7 +63,7 @@ jobs:
             --tags=http-server,https-server \
             --metadata=startup-script='#! /bin/bash
               apt-get update
-              apt-get install -y nginx
+              apt-get install -y nginx certbot python3-certbot-nginx
               systemctl enable nginx
               systemctl start nginx
             '
@@ -74,12 +76,15 @@ jobs:
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='
           if ! command -v nginx &> /dev/null; then
             sudo apt-get update
-            sudo apt-get install -y nginx
+            sudo apt-get install -y nginx certbot python3-certbot-nginx
           fi
           sudo systemctl enable nginx
           sudo systemctl start nginx
           sudo mkdir -p /var/www/html
           sudo chown -R $(whoami):$(whoami) /var/www/html
+
+          echo "Obtaining SSL certificate"
+          sudo certbot --nginx -d '"$DOMAIN"' --non-interactive --agree-tos --email devops@chan-ko.com
         '
 
         echo "Copying files..."
@@ -88,7 +93,32 @@ jobs:
         echo "Setting permissions and restarting nginx..."
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='
           sudo chown -R www-data:www-data /var/www/html
-          sudo systemctl restart nginx
+
+          echo '"Updating Nginx config to force HTTPS"'
+          sudo bash -c "cat > /etc/nginx/sites-available/default << EOF
+          server {
+              listen 80;
+              server_name '"$DOMAIN"';
+              return 301 https://\$server_name\$request_uri;
+          }
+
+          server {
+              listen 443 ssl;
+              server_name '"$DOMAIN"';
+
+              ssl_certificate /etc/letsencrypt/live/'"$DOMAIN"'/fullchain.pem;
+              ssl_certificate_key /etc/letsencrypt/live/'"$DOMAIN"'/privkey.pem;
+
+              root /var/www/html;
+              index index.html;
+
+              location / {
+                  try_files \$uri \$uri/ =404;
+              }
+          }
+          EOF"
+
+          sudo nginx -t && sudo systemctl restart nginx
         '
 
         gcloud compute ssh ${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }} --zone=${{ secrets.CHANKO_WEBSITE_GCE_ZONE }} --command='sudo mkdir -p /var/www/html && sudo chown -R $(whoami):$(whoami) /var/www/html'


### PR DESCRIPTION
Enabling HTTPS traffic for a website involves a few steps. We'll need to obtain an SSL certificate and configure Nginx to use it. Here is the process:

1. Obtain an SSL Certificate:
   We'll use Let's Encrypt, which provides free SSL certificates. We'll use the Certbot tool to obtain and manage these certificates.

2. Install Certbot and obtain the certificate:
   We'll need to add these steps to our deployment process.

3. Configure Nginx to use the SSL certificate.

Here's how we can modify our workflow to include these steps:



```yaml
name: Deploy to GCP

on:
  push:
    tags:
      - 'v*' # This will trigger the workflow for any tag starting with 'v'

jobs:
  deploy:
    runs-on: ubuntu-latest

    steps:
    # ... previous steps remain the same ...

    - name: Deploy to GCP
      env:
        DOMAIN: your-domain.com  # Replace with your actual domain
        CERTBOT_EMAIL: ${{ secrets.SOME_SECRET_EMAIL }} # Replace with actual value or a real secret
      run: |
        if ! gcloud compute instances describe ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }}; then
          gcloud compute instances create ${{ secrets.GCP_INSTANCE_NAME }} \
            --zone=${{ secrets.GCP_ZONE }} \
            --machine-type=e2-micro \
            --tags=http-server,https-server \
            --metadata=startup-script='#! /bin/bash
              apt-get update
              apt-get install -y nginx certbot python3-certbot-nginx
              systemctl enable nginx
              systemctl start nginx
            '
        fi
        
        # Wait for instance to be ready
        echo "Waiting for instance to be ready..."
        sleep 90
        
        # Ensure nginx is installed and running, obtain SSL certificate
        gcloud compute ssh ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }} --command='
          if ! command -v nginx &> /dev/null; then
            sudo apt-get update
            sudo apt-get install -y nginx certbot python3-certbot-nginx
          fi
          sudo systemctl enable nginx
          sudo systemctl start nginx
          sudo mkdir -p /var/www/html
          sudo chown -R $(whoami):$(whoami) /var/www/html
          
          # Obtain SSL certificate
          sudo certbot --nginx -d '"$DOMAIN"' --non-interactive --agree-tos --email your-email@example.com
        '
        
        # Copy files
        echo "Copying files..."
        gcloud compute scp --recurse --zone=${{ secrets.GCP_ZONE }} packages/chan-ko-website/dist/* ${{ secrets.GCP_INSTANCE_NAME }}:/var/www/html/
        
        # Set correct permissions, update Nginx config, and restart nginx
        echo "Setting permissions, updating Nginx config, and restarting nginx..."
        gcloud compute ssh ${{ secrets.GCP_INSTANCE_NAME }} --zone=${{ secrets.GCP_ZONE }} --command='
          sudo chown -R www-data:www-data /var/www/html
          
          # Update Nginx config to force HTTPS
          sudo bash -c "cat > /etc/nginx/sites-available/default << EOF
          server {
              listen 80;
              server_name '"$DOMAIN"';
              return 301 https://\$server_name\$request_uri;
          }

          server {
              listen 443 ssl;
              server_name '"$DOMAIN"';

              ssl_certificate /etc/letsencrypt/live/'"$DOMAIN"'/fullchain.pem;
              ssl_certificate_key /etc/letsencrypt/live/'"$DOMAIN"'/privkey.pem;

              root /var/www/html;
              index index.html;

              location / {
                  try_files \$uri \$uri/ =404;
              }
          }
          EOF"
          
          sudo nginx -t && sudo systemctl restart nginx
        '

    # ... rest of the workflow remains the same ...

```

Key changes in this update:

1. We've added installation of `certbot` and `python3-certbot-nginx` in the startup script.

2. We've added a step to obtain an SSL certificate using Certbot.

3. We've updated the Nginx configuration to force HTTPS and use the SSL certificate.

4. We've added an environment variable `DOMAIN` which you should replace with your actual domain name.
5. Added an environment variable `CERTBOT_EMAIL` which should be set from a github secret.

Additional considerations:

1. Domain Name: Ensure that our domain is pointing to the IP address of our GCP instance. Will need to set up an A record in our DNS settings.

2. Firewall Rules: Make sure our GCP firewall allows traffic on port 443 (HTTPS). To add this rule:

   ```
   gcloud compute firewall-rules create allow-https --allow tcp:443 --target-tags https-server
   ```

3. Email Address: The email address assigned to `CERTBOT_EMAIL` is used by Let's Encrypt for important notifications about your certificate.

4. Certificate Renewal: Certbot automatically sets up a cron job to renew the certificate before it expires. However, you might want to test this renewal process manually.

6. Security Headers: Consider adding security headers to your Nginx configuration for better security.

7. Performance: You might want to add caching headers and enable gzip compression in your Nginx configuration for better performance.

8. Redirect: The configuration forces all HTTP traffic to HTTPS. If you need to allow HTTP for any reason, you'll need to modify the Nginx configuration.

9. Rate Limiting: Consider implementing rate limiting in Nginx to protect against potential DoS attacks.

Finally, we must ensure that we have the necessary DNS records set up to point our domain to our GCE instance's IP address.