### PR TITLE
fix: update yml to properly expand DOMAIN var

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -102,19 +102,20 @@ jobs:
           sudo chown -R www-data:www-data /var/www/html
 
           echo "Updating Nginx config to force HTTPS"
+          DOMAIN='"$DOMAIN"'
           sudo bash -c "cat > /etc/nginx/sites-available/default << EOL
         server {
             listen 80;
-            server_name $DOMAIN;
+            server_name \$DOMAIN;
             return 301 https://\$server_name\$request_uri;
         }
 
         server {
             listen 443 ssl;
-            server_name $DOMAIN;
+            server_name \$DOMAIN;
 
-            ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
-            ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+            ssl_certificate /etc/letsencrypt/live/\$DOMAIN/fullchain.pem;
+            ssl_certificate_key /etc/letsencrypt/live/\$DOMAIN/privkey.pem;
 
             root /var/www/html;
             index index.html;


### PR DESCRIPTION
Received the following debug output from our last run.

```
Updating Nginx config to force HTTPS
Nginx configuration created. Checking syntax...
2024/07/20 21:58:54 [emerg] 84526#84526: invalid number of arguments in "server_name" directive in /etc/nginx/sites-enabled/default:3
nginx: configuration file /etc/nginx/nginx.conf test failed
Nginx syntax check failed. Printing configuration file:
server ***
    listen 80;
    server_name ;
    return 301 https://;
***
server ***
    listen 443 ssl;
    server_name ;
    ssl_certificate /etc/letsencrypt/live//fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live//privkey.pem;
    root /var/www/html;
    index index.html;
    location / ***
        try_files  / =404;
    ***
***
Error: Process completed with exit code 1.
```

It seems that the environment variables are not being properly expanded within the Nginx configuration. This PR modifies the script to ensure that the `$DOMAIN` variable is correctly passed and expanded.

Key changes in this update:

1. Added `DOMAIN='"$DOMAIN"'` before the Nginx configuration to ensure the `$DOMAIN` variable is available within the SSH session.
2. Changed `$DOMAIN` to `\$DOMAIN` in the Nginx configuration to ensure proper expansion within the heredoc.

These changes should resolve the issue with the empty `server_name` directive and other related problems in the Nginx configuration.

This version should correctly expand the `$DOMAIN` variable in the Nginx configuration, resolving the "invalid number of arguments in server_name directive" error.