### PR TITLE
debug: Adding more debugging for nginx

### DIFF
--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -78,7 +78,7 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
 
-    add_header Strict-Transport-Security \"max-age=31536000\; includeSubDomains\" always;
+    add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains\" always;
 
     root /var/www/html;
     index index.html;
@@ -135,3 +135,15 @@ gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command="
   echo 'Listening ports:'
   sudo netstat -tuln
 "
+
+echo 'Nginx configuration in use:'
+sudo nginx -T | grep -v '#'
+
+echo 'Testing HTTP to HTTPS redirect:'
+curl -I http://$DOMAIN
+
+echo 'SSL certificate information:'
+openssl s_client -connect $DOMAIN:443 -servername $DOMAIN < /dev/null 2>/dev/null | openssl x509 -noout -text
+
+echo 'Nginx warnings or errors:'
+sudo journalctl -u nginx


### PR DESCRIPTION
# Claude 3 Output summary:
The Nginx configuration in our script looks correct now, including:

1. The HTTP to HTTPS redirect:
   ```
   return 301 https://\$server_name\$request_uri;
   ```

2. The `try_files` directive:
   ```
   try_files \$uri \$uri/ /index.html;
   ```

Given that these correct configurations are already in place, we need to investigate why you're still experiencing the ERR_INVALID_REDIRECT error. We'll focus on debugging the actual server behavior rather than the script itself.

We are taking these steps to diagnose the issue:

1. Check if the Nginx configuration is being applied correctly:
   Added this command to our debugging section:
   ```bash
   echo 'Nginx configuration in use:'
   sudo nginx -T | grep -v '#'
   ```
   This will show the actual configuration Nginx is using, which might differ from the file we're writing.

2. Test the HTTP to HTTPS redirect manually:
   Added these commands to our debugging section:
   ```bash
   echo 'Testing HTTP to HTTPS redirect:'
   curl -I http://$DOMAIN
   ```
   This will show the HTTP response headers for a request to the HTTP version of our site.

3. Check SSL certificate validity:
   Added this command to our debugging section:
   ```bash
   echo 'SSL certificate information:'
   openssl s_client -connect $DOMAIN:443 -servername $DOMAIN < /dev/null 2>/dev/null | openssl x509 -noout -text
   ```
   This will provide detailed information about the SSL certificate being used.

4. Check for any Nginx warnings or errors that might not appear in the error log:
   Added this command to our debugging section:
   ```bash
   echo 'Nginx warnings or errors:'
   sudo journalctl -u nginx
   ```
   This will show any Nginx-related messages in the system journal.

This additional information should help us identify why the redirect isn't working as expected, despite the correct configuration in the file.