### PR TITLE
fix: attempts to fix HTTPS redirect issue

### DIFF
--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -57,12 +57,19 @@ gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command="
 server {
     listen 80;
     server_name $DOMAIN;
+
+    # Add debugging information
+    add_header X-Debug-Message \"HTTP server block\" always;
+
     return 301 https://\$server_name\$request_uri;
 }
 
 server {
     listen 443 ssl http2;
     server_name $DOMAIN;
+
+    # Add debugging information
+    add_header X-Debug-Message \"HTTPS server block\" always;
 
     ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;


### PR DESCRIPTION
# Claude 3 output summary
The ERR_TOO_MANY_REDIRECTS error typically occurs when there's a loop in the redirection process. The issue is likely in the server configuration or possibly with Cloudflare. 

First, we will modify the Nginx configuration to add some debugging information and ensure we're not causing a redirect loop:

```bash
#!/bin/bash

# ... (keep the existing content, but replace the Nginx configuration section with the following)

echo "Setting permissions and updating Nginx config..."
gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command="
  sudo chown -R www-data:www-data /var/www/html

  echo 'Updating Nginx config to force HTTPS and improve SSL settings'
  cat << EOF | sudo tee /etc/nginx/sites-available/default
server {
    listen 80;
    server_name $DOMAIN;
    
    # Add debugging information
    add_header X-Debug-Message \"HTTP server block\" always;
    
    return 301 https://\$server_name\$request_uri;
}

server {
    listen 443 ssl http2;
    server_name $DOMAIN;

    # Add debugging information
    add_header X-Debug-Message \"HTTPS server block\" always;

    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;

    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_prefer_server_ciphers on;
    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

    ssl_session_cache shared:SSL:10m;
    ssl_session_timeout 1d;
    ssl_session_tickets off;

    ssl_stapling on;
    ssl_stapling_verify on;

    add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains\" always;

    root /var/www/html;
    index index.html;

    location / {
        try_files \$uri \$uri/ /index.html;
    }
}
EOF

  echo 'Nginx configuration created. Checking syntax...'
  sudo nginx -t

  if [ \$? -eq 0 ]; then
    echo 'Nginx syntax is correct. Restarting Nginx...'
    sudo systemctl restart nginx
  else
    echo 'Nginx syntax check failed. Printing configuration file:'
    cat /etc/nginx/sites-available/default
    exit 1
  fi

  echo 'Nginx status:'
  sudo systemctl status nginx
"

# ... (keep the rest of the script)

```

After updating the script with these changes:

1. Create a new tag (e.g., `v1.0.18`) to trigger the workflow.

2. Once the deployment is complete, try accessing your website again.

3. If you still encounter the redirect loop, use a tool like `curl` to check the headers:

   ```
   curl -I http://chan-ko.com
   curl -I https://chan-ko.com
   ```

   Look for the `X-Debug-Message` header in the responses. This will help us understand which server block is handling the request.

4. Check your Cloudflare settings:
   - Log in to your Cloudflare dashboard
   - Go to the SSL/TLS section
   - Ensure that SSL is set to "Full" or "Full (strict)"
   - In the "Edge Certificates" section, make sure "Always Use HTTPS" is turned OFF (since your Nginx is already handling this)

5. In the Cloudflare "Rules" section, check if there are any Page Rules that might be causing redirects.

6. If you're using Cloudflare, temporarily pause Cloudflare (put your site on "DNS only" mode) to see if the issue persists when connecting directly to your server.

After performing these steps, we will use the following information to further investigate:

- The output of the `curl` commands
- Current Cloudflare SSL/TLS and Page Rules settings
- Whether the issue persists when Cloudflare is paused

This information will help us pinpoint the exact cause of the redirect loop and resolve it.