### PR TITLE
fix: add debug headers for nginx

### DIFF
--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -70,6 +70,8 @@ server {
 
     # Add debugging information
     add_header X-Debug-Message \"HTTPS server block\" always;
+    add_header X-URI \$uri always;
+    add_header X-Request-URI \$request_uri always;
 
     ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;


### PR DESCRIPTION
# Claude 3.5 Output summary:

We're still facing issues with the Nginx configuration. Let's analyze the problems:

1. The HTTP redirect is still incorrect, as it's redirecting to "https://" without the domain.
2. The HTTPS server is creating a redirect loop by redirecting to itself.
3. The website files are present in the `/var/www/html` directory, which is good.

Key change in this update:

Added `add_header X-URI $uri always;` and `add_header X-Request-URI $request_uri always;` in the HTTPS server block for additional debugging.

After updating the script with these changes:

1. Create a new tag (e.g., `v1.0.21`) to trigger the workflow.
2. Once the deployment is complete, try accessing your website again.
3. Use curl to check the headers again:

   ```
   curl -I http://chan-ko.com
   curl -I -k https://chan-ko.com
   ```

4. Check the content of the index.html file:

   ```
   cat /var/www/html/index.html
   ```

5. Check the Nginx access logs:

   ```
   sudo tail -n 50 /var/log/nginx/access.log
   ```

After performing these steps, please provide:

- The new output of the curl commands
- The content of the index.html file
- The relevant entries from the Nginx access log
- The Nginx configuration file content that was printed at the end of the deployment process

This additional information will help us identify why the redirect loop is still occurring and determine if there are any issues with the website content or how Nginx is handling requests.