### PR TITLE
Fix for ssl mismatch

### DIFF
--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -52,11 +52,8 @@ echo "Setting permissions and updating Nginx config..."
 gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command='
   sudo chown -R www-data:www-data /var/www/html
 
-  # Get the actual hostname
-  ACTUAL_HOSTNAME=$(hostname -f)
-
   echo "Updating Nginx config to force HTTPS and improve SSL settings"
-  cat << ENDOFNGINXCONF | sudo tee /etc/nginx/sites-available/default
+  cat << "ENDOFNGINXCONF" | sudo tee /etc/nginx/sites-available/default
 server {
     listen 80;
     server_name chan-ko.com;
@@ -66,7 +63,7 @@ server {
     add_header X-Host $host always;
     add_header X-Server-Name $server_name always;
 
-    return 301 https://$host$request_uri;
+    return 301 https://$server_name$request_uri;
 }
 
 server {
@@ -127,12 +124,9 @@ ENDOFNGINXCONF
   sudo cat /etc/nginx/sites-available/default
 
   echo "Testing Nginx variables:"
-  echo "ACTUAL_HOSTNAME: $ACTUAL_HOSTNAME"
+  echo "SERVER_NAME: chan-ko.com"
   curl -H "Host: chan-ko.com" -I http://localhost
-  curl -k -H "Host: chan-ko.com" -I https://localhost
-
-  echo "Checking SSL certificate:"
-  sudo certbot certificates
+  curl -H "Host: chan-ko.com" -I https://localhost
 '
 
 gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command="sudo mkdir -p /var/www/html && sudo chown -R \$(whoami):\$(whoami) /var/www/html"

--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -56,7 +56,7 @@ gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command='
   cat << "ENDOFNGINXCONF" | sudo tee /etc/nginx/sites-available/default
 server {
     listen 80;
-    server_name $DOMAIN;
+    server_name chan-ko.com;
 
     # Add debugging information
     add_header X-Debug-Message "HTTP server block" always;
@@ -68,7 +68,7 @@ server {
 
 server {
     listen 443 ssl http2;
-    server_name $DOMAIN;
+    server_name chan-ko.com;
 
     # Add debugging information
     add_header X-Debug-Message "HTTPS server block" always;
@@ -77,8 +77,8 @@ server {
     add_header X-URI $uri always;
     add_header X-Request-URI $request_uri always;
 
-    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/chan-ko.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/chan-ko.com/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;

--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -119,14 +119,6 @@ ENDOFNGINXCONF
 
   echo "Nginx status:"
   sudo systemctl status nginx
-
-  echo "Printing Nginx configuration:"
-  sudo cat /etc/nginx/sites-available/default
-
-  echo "Testing Nginx variables:"
-  echo "SERVER_NAME: chan-ko.com"
-  curl -H "Host: chan-ko.com" -I http://localhost
-  curl -H "Host: chan-ko.com" -I https://localhost
 '
 
 gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command="sudo mkdir -p /var/www/html && sudo chown -R \$(whoami):\$(whoami) /var/www/html"

--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -56,7 +56,7 @@ gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command='
   cat << "ENDOFNGINXCONF" | sudo tee /etc/nginx/sites-available/default
 server {
     listen 80;
-    server_name chan-ko.com;
+    server_name $DOMAIN;
 
     # Add debugging information
     add_header X-Debug-Message "HTTP server block" always;
@@ -68,7 +68,7 @@ server {
 
 server {
     listen 443 ssl http2;
-    server_name chan-ko.com;
+    server_name $DOMAIN;
 
     # Add debugging information
     add_header X-Debug-Message "HTTPS server block" always;
@@ -77,8 +77,8 @@ server {
     add_header X-URI $uri always;
     add_header X-Request-URI $request_uri always;
 
-    ssl_certificate /etc/letsencrypt/live/chan-ko.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/chan-ko.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;


### PR DESCRIPTION
With PR #45 we were able to finally get the Nginx built-in variables to show up in the final conf file that our script creates.
As can be seen from this snippet from the `chan-ko-website-deploy` workflow logs:
```
Printing Nginx configuration:
server ***
    listen 80;
    server_name $hostname;

    # Add debugging information
    add_header X-Debug-Message "HTTP server block" always;
    add_header X-Host $host always;
    add_header X-Server-Name $server_name always;

    return 301 https://$server_name$request_uri;
***

server ***
    listen 443 ssl http2;
    server_name $hostname;

    # Add debugging information
    add_header X-Debug-Message "HTTPS server block" always;
    add_header X-Host $host always;
    add_header X-Server-Name $server_name always;
    add_header X-URI $uri always;
    add_header X-Request-URI $request_uri always;

    ssl_certificate /etc/letsencrypt/live/$hostname/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/$hostname/privkey.pem;

    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_prefer_server_ciphers off;
    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

    ssl_session_cache shared:SSL:10m;
    ssl_session_timeout 1d;
    ssl_session_tickets off;

    ssl_stapling on;
    ssl_stapling_verify on;

    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

    root /var/www/html;
    index index.html;

    location / ***
        try_files $uri $uri/ /index.html;
    ***

    # Disable SSL handshake debugging for better performance
    error_log /var/log/nginx/error.log warn;
***
```

This was great, however as can be seen it is using `$hostname` as the `server_name`. But hostname actually evaluates to whatever name the GCE instance was named during creation, and we need the server_name to match the SSL cert (which uses `chan-ko.com`).

For whatever reason, Claude and ChatGPT weren't catching that. Therefore I was able to get the Nginx conf configured properly sans AI this time.