### PR TITLE
cd: only allow logging in non-production env

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -40,7 +40,7 @@ jobs:
       run: pnpm install --filter chan-ko-website
 
     - name: Build website
-      run: VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT=${{ secrets.CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT }} pnpm --filter chan-ko-website build
+      run: VITE_ENVIRONMENT=prod VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT=${{ secrets.CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT }} pnpm --filter chan-ko-website build
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v1

--- a/packages/chan-ko-website/.env
+++ b/packages/chan-ko-website/.env
@@ -1,1 +1,2 @@
+VITE_ENVIRONMENT=prod
 VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT=https://default-api.example.com

--- a/packages/chan-ko-website/src/components/ContactForm/ContactForm.tsx
+++ b/packages/chan-ko-website/src/components/ContactForm/ContactForm.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect, ChangeEvent, FormEvent} from 'react';
 import styles from './ContactForm.module.css';
 import {countries} from './countries';
 
-const CONTACT_FORM_ENDPOINT = import.meta.env.VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT || '';
+const GetContactFormEndpoint = () => import.meta.env.VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT;
 
 interface FormData {
   firstName: string;
@@ -16,12 +16,14 @@ interface FormData {
 }
 
 const ContactForm: React.FC = () => {
-  useEffect(() => {
-    if (import.meta.env.VITE_ENVIRONMENT !== 'prod') {
-      // We only want to log if we're not in production.
-      console.log('Current API Endpoint:', CONTACT_FORM_ENDPOINT);
-    }
-  }, []);
+  const endpoint = GetContactFormEndpoint();
+
+  if (import.meta.env.VITE_ENVIRONMENT !== 'prod') {
+    // We only want to log if we're not in production.
+    console.log('Current API Endpoint:', endpoint);
+  }
+
+  useEffect(() => {}, []);
 
   const [formData, setFormData] = useState<FormData>({
     firstName: '',
@@ -60,14 +62,14 @@ const ContactForm: React.FC = () => {
     e.preventDefault();
     setSubmitStatus('submitting');
 
-    if (!CONTACT_FORM_ENDPOINT) {
+    if (!endpoint) {
       console.error('CONTACT_FORM_ENDPOINT is not defined');
       setSubmitStatus('error');
       return;
     }
 
     try {
-      const response = await fetch(CONTACT_FORM_ENDPOINT, {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'text/plain;charset=utf-8',

--- a/packages/chan-ko-website/src/components/ContactForm/ContactForm.tsx
+++ b/packages/chan-ko-website/src/components/ContactForm/ContactForm.tsx
@@ -17,7 +17,10 @@ interface FormData {
 
 const ContactForm: React.FC = () => {
   useEffect(() => {
-    console.log('Current API Endpoint:', CONTACT_FORM_ENDPOINT);
+    if (import.meta.env.VITE_ENVIRONMENT !== 'prod') {
+      // We only want to log if we're not in production.
+      console.log('Current API Endpoint:', CONTACT_FORM_ENDPOINT);
+    }
   }, []);
 
   const [formData, setFormData] = useState<FormData>({

--- a/packages/chan-ko-website/test/components/ContactForm/ContactForm.test.tsx
+++ b/packages/chan-ko-website/test/components/ContactForm/ContactForm.test.tsx
@@ -1,8 +1,79 @@
-import { describe, it, expect } from 'vitest';
+/**
+ * @fileoverview Test suite for the ContactForm component.
+ *
+ * This file contains unit tests for the ContactForm component, which is responsible
+ * for rendering and handling user input in a contact form. The tests cover various
+ * scenarios including:
+ *
+ * - Logging behavior in different environments (development, production, undefined)
+ * - Rendering of form elements
+ *
+ * The test suite uses Vitest for test running and assertion, and React Testing Library
+ * for rendering and querying the component. It also employs mocking techniques to
+ * isolate the component from its dependencies and control the testing environment.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ContactForm from '../../../src/components/ContactForm';
 
+// Utility to mock import.meta.env
+const setMockEnv = (env: Record<string, unknown>) => {
+  const originalEnv = {...import.meta.env};
+  Object.assign(import.meta.env, env);
+
+  return () => {
+    Object.assign(import.meta.env, originalEnv);
+  };
+};
+
+// Mocking console.log
+vi.spyOn(console, 'log').mockImplementation(() => {});
+
 describe('ContactForm', () => {
+  let resetEnv: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (resetEnv) resetEnv();
+  });
+
+  it('logs Current API Endpoint when ENV is not prod', () => {
+    resetEnv = setMockEnv({
+      VITE_ENVIRONMENT: 'dev',
+      VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT: 'http://localhost:3000',
+    });
+
+    render(<ContactForm />);
+
+    expect(console.log).toHaveBeenCalledWith('Current API Endpoint:', 'http://localhost:3000');
+  });
+
+  it('logs Current API Endpoint when values are undefined', () => {
+    resetEnv = setMockEnv({
+      VITE_ENVIRONMENT: undefined,
+      VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT: undefined,
+    });
+
+    render(<ContactForm />);
+
+    expect(console.log).toHaveBeenCalledWith('Current API Endpoint:', 'undefined');
+  });
+
+  it('does not log Base URL and Environment when ENV is prod', () => {
+    resetEnv = setMockEnv({
+      VITE_ENVIRONMENT: 'prod',
+      VITE_CHANKO_WEBSITE_CONTACT_FORM_ENDPOINT: 'http://localhost:3000',
+    });
+
+    render(<ContactForm />);
+
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
   it('renders contact form', () => {
     render(<ContactForm />);
 


### PR DESCRIPTION
This change makes it so that the logging that currently exists in the app only shows up in non-production environments. This is done to prevent possible leaking of non-public information.