### PR TITLE
fix: updates workflow release step to use correct secret

### DIFF
--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Create GitHub Release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}

--- a/.github/workflows/chan-ko-website-deploy.yml
+++ b/.github/workflows/chan-ko-website-deploy.yml
@@ -60,12 +60,19 @@ jobs:
         chmod +x ./deploy-chan-ko-website.sh
         ./deploy-chan-ko-website.sh "$DOMAIN" "$CERTBOT_EMAIL" "${{ secrets.CHANKO_WEBSITE_GCE_INSTANCE_NAME }}" "${{ secrets.CHANKO_WEBSITE_GCE_ZONE }}"
 
+    - name: Install GitHub CLI
+      run: |
+        type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+        && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+        && sudo apt update \
+        && sudo apt install gh -y
+
     - name: Create GitHub Release
-      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
+      run: |
+        gh release create ${{ github.ref_name }} \
+          --title "Release ${{ github.ref_name }}" \
+          --draft --generate-notes


### PR DESCRIPTION
Our `Deploy to GCP` job has been failing at the `Create GitHub Release` step because the `GITHUB_TOKEN` provided by default doesn't have the necessary permissions to create releases. To resolve this, we need to use a Personal Access Token (PAT) with the required permissions.

Key changes in this update:
1. We've added a new step called "Install GitHub CLI" before the "Create GitHub Release" step.
2. This new step installs the GitHub CLI (gh) using the official installation script.
3. We've changed `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to `GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}`.
4. We're now using the GitHub CLI (gh)
5. We are using `github.ref_name` instead of `github.ref` to get just the tag name without the refs/tags/ prefix.

Additional considerations:
1. Token Permissions: Ensure that your RELEASE_TOKEN has the necessary permissions to create releases. It should have the repo scope or at least public_repo if your repository is public.
2. Release Assets: If you want to attach any assets to your release (like compiled binaries), you can add them using the --attach flag in the gh release create command.
3. Draft Releases: If you want to create draft releases that you can review before publishing, you can add the --draft flag to the gh release create command.
4. Pre-releases: For pre-release versions, you can add the --prerelease flag.
5. Release Notes: The --generate-notes flag automatically generates release notes based on your pull requests and commits. If you want to provide custom notes, you can use the --notes flag instead.
6. Conditional Release Creation: If you want to make release creation conditional (e.g., only for production releases), you can add a condition to this step.

Here is a more advanced release step:
```yaml
- name: Create GitHub Release
  env:
    GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
  run: |
    gh release create ${{ github.ref_name }} \
      --title "Release ${{ github.ref_name }}" \
      --generate-notes \
      --notes-file RELEASE_NOTES.md \
      --attach ./dist/* \
      ${{ startsWith(github.ref, 'refs/tags/v') && '|| true' }}
```
This version:
- Creates a release with the tag name
- Generates automatic release notes
- Appends custom notes from a RELEASE_NOTES.md file
- Attaches all files in the ./dist directory
- Doesn't fail the workflow if the release already exists (useful for re-runs)