### PR TITLE
chore: repositions assets in the footer

### DIFF
--- a/packages/chan-ko-website/src/components/Footer/Footer.tsx
+++ b/packages/chan-ko-website/src/components/Footer/Footer.tsx
@@ -49,8 +49,9 @@ const Footer: React.FC = () => {
             <Instagram />
           </a>
         </div>
+        <div>Build: {GetVersion()}</div>
         <p className={styles.copyright}>
-        Build: {GetVersion()} | &copy; {new Date().getFullYear()} Chan-Ko LLC. All rights reserved.
+        &copy; {new Date().getFullYear()} Chan-Ko LLC. All rights reserved.
         </p>
       </div>
     </footer>


### PR DESCRIPTION
This moves the Build info above the copyright info, rather than beside it.