### PR TITLE
fix: create_calver_tag.sh uses correct shebang now

### DIFF
--- a/create_calver_tag.sh
+++ b/create_calver_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get today's UTC date in the required format
 TODAY=$(date -u +"%y.%m.%d")


### PR DESCRIPTION
The original shebang used points to a non-existent location for bash on NixOS systems.
This change updates to a recommend shebang.

see: https://discourse.nixos.org/t/how-do-you-run-a-bash-script/10141/3