### PR TITLE
Prevent pushes to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ devenv.local.nix
 
 # pre-commit
 .pre-commit-config.yaml
+scripts/prevent-main-commits.sh
 
 # TypeScript dependencies
 node_modules

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,7 +12,11 @@
   ];
 
   # https://devenv.sh/scripts/
-  scripts.hello.exec = ''echo -e "\033[0;32m### Welcome to the $GREET! ###\033[0m"'';
+  scripts = {
+    hello.exec = ''echo -e "\033[0;32m### Welcome to the $GREET! ###\033[0m"'';
+    no-main-branch-commits.exec = ''bash scripts/prevent-main-commits.sh'';
+    no-main-branch-pushes.exec = ''bash scripts/prevent-main-push.sh'';
+  };
 
   enterShell = ''
     hello
@@ -20,6 +24,17 @@
 
   # https://devenv.sh/pre-commit-hooks/
   pre-commit.hooks = {
+    no-main-branch-commits = {
+      enable = true;
+      entry = "no-main-branch-commits";
+    };
+
+    no-main-branch-pushes = {
+      enable = true;
+      entry = "no-main-branch-pushes";
+      stages = [ "pre-push" ];
+    };
+
     chan-ko-testing = {
       enable = true;
       name = "Chan-Ko Website Testing";

--- a/scripts/prevent-main-commits.sh
+++ b/scripts/prevent-main-commits.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo -e "\033[0;32m### Current branch is ${CURRENT_BRANCH} ###\033[0m"
+
+# Uncomment the pre-commit check below if this is your local dev environment.
+# if [[ "${CURRENT_BRANCH}" == "main" ]]; then
+# echo -e "\033[0;31m### You are not allowed to commit to the main branch! ###\033[0m";
+# exit 1;
+# fi
+# echo -e "\033[0;32m### You are allowed to commit to the ${CURRENT_BRANCH} branch! ###\033[0m";
+
+# Delete this echo statement if you are in local dev environment.
+echo -e "\033[0;31m### Please delete this statement and uncomment the pre-commit ###
+### code above if this is your local dev environment. ###
+### If you're confused see ./scripts/prevent-main-commits.sh\033[0m"

--- a/scripts/prevent-main-push.sh
+++ b/scripts/prevent-main-push.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROTECTED_BRANCH='main'
+CURRENT_BRANCH=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ $PROTECTED_BRANCH = $CURRENT_BRANCH ]
+then
+    echo "\033[0;31m## ${PROTECTED_BRANCH} is a protected branch, create a PR to merge\033[0m"
+    exit 1 # push will not execute
+else
+    echo "\033[0;32m## It is safe to push to the ${CURRENT_BRANCH} branch.\033[0m"
+    exit 0 # push will execute
+fi


### PR DESCRIPTION
These changes are intended to prevent devs from inadvertently pushing changes directly to the `main` branch.

Dev's should be able to uncomment the correct lines in `scripts/prevent-main-commits.sh` which will also prevent accidental commits, but even without updating that file any commits made will not be able to be pushed to main. They will need to first be added to a separate branch and merged through a PR.