### PR TITLE
fix: address issues with deploy script syntax

### DIFF
--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -63,6 +63,7 @@ EOF
     echo 'No certificate found for either domain. Creating a new one for both domains.'
     sudo certbot --nginx -d '$DOMAIN' -d '$WWW_DOMAIN' --non-interactive --agree-tos --email '$CERTBOT_EMAIL'
   fi
+"
 
 echo "Copying files..."
 gcloud compute scp --recurse --zone="$GCE_ZONE" packages/chan-ko-website/dist/* "$GCE_INSTANCE_NAME":/var/www/html/

--- a/deploy-chan-ko-website.sh
+++ b/deploy-chan-ko-website.sh
@@ -73,19 +73,19 @@ gcloud compute ssh "$GCE_INSTANCE_NAME" --zone="$GCE_ZONE" --command='
   sudo chown -R www-data:www-data /var/www/html
 
   echo "Updating Nginx config to force HTTPS and improve SSL settings"
-  cat << "ENDOFNGINXCONF" | sudo tee /etc/nginx/sites-available/default
+  cat << ENDOFNGINXCONF | sudo tee /etc/nginx/sites-available/default
 server {
     listen 80;
-    server_name $DOMAIN $WWW_DOMAIN;
-    return 301 https://$host$request_uri;
+    server_name '"$DOMAIN"' '"$WWW_DOMAIN"';
+    return 301 https://\$host\$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name $DOMAIN $WWW_DOMAIN;
+    server_name '"$DOMAIN"' '"$WWW_DOMAIN"';
 
-    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/'"$DOMAIN"'/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/'"$DOMAIN"'/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
@@ -104,7 +104,7 @@ server {
     index index.html;
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files \$uri \$uri/ /index.html;
     }
 }
 ENDOFNGINXCONF


### PR DESCRIPTION
Restores a `"` which was accidently deleted in a previous pull request. The missing quotation mark is causing the deployment script to fail with the following error output:
```shell
Waiting for instance to be ready...
Ensure nginx is installed and running, and update configuration
./deploy-***.sh: line 127: syntax error near unexpected token `('
Error: Process completed with exit code 2.
```

Also fixes an issue where the problem is that the shell variables are not being expanded in the Nginx configuration. This is happening because we're using single quotes for the heredoc, which prevents variable expansion. We can fix this by changing the heredoc delimiter and escaping the necessary characters.

# Claude 3.5
Key changes:

1. Changed the heredoc delimiter from `"ENDOFNGINXCONF"` to `ENDOFNGINXCONF` (without quotes). This allows variable expansion within the heredoc.
2. Wrapped `$DOMAIN` and `$WWW_DOMAIN` in single quotes and double quotes: `'"$DOMAIN"'`. This allows these shell variables to be expanded while still being properly quoted in the Nginx configuration.
3. Escaped the `$` in `$host` and `$uri` with a backslash: `\$host`, `\$uri`. This prevents these Nginx variables from being interpreted as shell variables.