### PR TITLE
ux: makes the scroll instant when closing case study

### DIFF
--- a/packages/chan-ko-website/src/components/CaseStudies/CaseStudies.tsx
+++ b/packages/chan-ko-website/src/components/CaseStudies/CaseStudies.tsx
@@ -158,7 +158,6 @@ Through our fractional CTO services, we successfully transformed the computer vi
             const cardElement = cardRefs.current[prevExpandedId];
             if (cardElement) {
                 cardElement.scrollIntoView({
-                    behavior: 'smooth',
                     block: 'nearest'
                 });
             }


### PR DESCRIPTION
The previous scroll behavior associated with closing a case study was a bit jarring, as it showed the user a location further down the web page before abruptly scrolling back to the correct position in the page.

With this change the user is instantly taken to the correct position without the awkward transition.